### PR TITLE
Fixed initial dark theme for Chrome and Firefox

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -20,6 +20,8 @@ window.matchMedia("(prefers-color-scheme: dark)").addListener(query => {
   updateColorScheme()
 })
 
+window.onload = updateColorScheme()
+
 document.getElementById("icon").addEventListener("click", () => {
   changeThemeOverride()
   updateColorScheme()


### PR DESCRIPTION
For some reason the theme was not drawn even though it was selected. With a window.onload call for updateColorScheme it should work on both browsers now.